### PR TITLE
Allow to accept tiffs only on local file input

### DIFF
--- a/src/components/uploader/imagery-location.js
+++ b/src/components/uploader/imagery-location.js
@@ -77,6 +77,7 @@ export default class extends React.Component {
           <div>
             <input
               type="file"
+              accept=".tif, .tiff"
               className=""
               placeholder="Local file"
               {...opts}


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/FE-User-can-select-not-.tiff-or-.tif-files-when-uploading-a-local-file-15055