### PR TITLE
Hide GDrive upload button

### DIFF
--- a/src/components/uploader/scene.js
+++ b/src/components/uploader/scene.js
@@ -264,7 +264,7 @@ Please check the instructions on how to use files from Google Drive.
               <DropboxIcon />
               <span>Dropbox</span>
             </button>
-            <button
+            {/* <button
               type="button"
               className="bttn bttn-primary bttn-icon"
               onClick={this.importGDriveClick}
@@ -272,7 +272,7 @@ Please check the instructions on how to use files from Google Drive.
             >
               <GoogleDriveIcon />
               <span>Drive</span>
-            </button>
+            </button> */}
             {this.props.renderErrorMessage(
               this.props.getValidationMessages("scenes." + i + ".img-loc")[0]
             )}


### PR DESCRIPTION
The GDrive upload button hidden

https://kontur.fibery.io/Tasks/Task/Uploading-files-from-Google-Drive-is-not-possible-on-prod-16164